### PR TITLE
Refactor: Adjust site spacing and remove footer social links

### DIFF
--- a/posts.html
+++ b/posts.html
@@ -43,10 +43,6 @@
     </main>
     <footer>
         <p>&copy; <span id="current-year"></span> Alon Torres. All rights reserved.</p>
-        <div class="footer-links">
-            <a href="https://linkedin.com/in/yourprofile" target="_blank" rel="noopener noreferrer">LinkedIn</a> | 
-            <a href="https://github.com/yourusername" target="_blank" rel="noopener noreferrer">GitHub</a>
-        </div>
     </footer>
 
     <script src="posts_config.js"></script> <!-- Load post configurations -->

--- a/style.css
+++ b/style.css
@@ -110,7 +110,7 @@ main {
     padding: 2rem 0;
     width: 90%;
     max-width: 800px; /* Max width for readability */
-    margin: 3rem auto 2rem; /* Centering and spacing (top, horizontal, bottom) */
+    margin: 1.5rem auto 2rem; /* Centering and spacing (top, horizontal, bottom) */
 }
 
 main section {
@@ -123,11 +123,12 @@ main section {
 
 main h2 {
     color: var(--accent-color); /* Changed from primary-text-color */
+    margin-top: 0; /* Override general h2 margin-top */
     margin-bottom: 0.75rem; /* Closer to its content */
     /* border-bottom: 2px solid var(--accent-color); Removed */
     /* padding-bottom: 8px; Removed */
     border-top: 1px solid var(--border-color); /* Added */
-    padding-top: 1rem; /* Space from top border. Will inherit margin-top from general h rule */
+    padding-top: 0.5rem; /* Space from top border. Will inherit margin-top from general h rule */
     letter-spacing: 0.25px; /* Subtle letter spacing for definition */
 }
 


### PR DESCRIPTION
This commit addresses several spacing and layout issues to improve visual balance across screen sizes:

- Reduced top margin for the main content area to lessen whitespace between the header/navigation and the content below it.
- Adjusted internal padding within content cards by modifying the top margin and padding of H2 headings within sections (e.g., "Who I Am", "Published Posts") for a less top-heavy feel.
- Removed social media links (LinkedIn, GitHub) from the footer of the posts page to ensure no such links are present on the site.

These changes apply to the homepage, posts list page, and individual post pages, aiming for a more consistent and cleaner presentation.